### PR TITLE
Coerce optimizer name to string in set_parameters_ECmodel!

### DIFF
--- a/src/ECModel.jl
+++ b/src/ECModel.jl
@@ -1273,7 +1273,15 @@ function set_parameters_ECmodel!(ECModel::AbstractEC,
     model = ECModel.model
     deterministic_model = ECModel.deterministic_model
 
-    if occursin("CPLEX", ECModel.optimizer )
+    # `ECModel.optimizer` may be stored as a Type (e.g. `Gurobi.Optimizer`),
+    # an instance, or already a string — coerce to string so `occursin` is
+    # well-defined in all three cases. Without this, passing the optimizer
+    # as `Gurobi.Optimizer` makes the function silently fall through (or,
+    # depending on the call path, raise a MethodError on the first
+    # `occursin`), and none of the parameters end up applied.
+    optimizer_name = string(ECModel.optimizer)
+
+    if occursin("CPLEX", optimizer_name)
         set_optimizer_attribute(model, "CPX_PARAM_EPGAP", tol)
         set_optimizer_attribute(model, "CPX_PARAM_TILIM", time_limit)
         set_optimizer_attribute(model, "CPX_PARAM_THREADS", threads)
@@ -1284,7 +1292,7 @@ function set_parameters_ECmodel!(ECModel::AbstractEC,
         set_optimizer_attribute(deterministic_model, "CPX_PARAM_THREADS", threads)
         set_optimizer_attribute(deterministic_model, "CPX_PARAM_SCRIND", verbosity)
 
-    elseif occursin("HiGHS", ECModel.optimizer)
+    elseif occursin("HiGHS", optimizer_name)
         set_optimizer_attribute(model, "mip_rel_gap", tol)
         set_optimizer_attribute(model, "time_limit", time_limit)
         set_optimizer_attribute(model, "threads", threads)
@@ -1295,7 +1303,7 @@ function set_parameters_ECmodel!(ECModel::AbstractEC,
         set_optimizer_attribute(deterministic_model, "threads", threads)
         set_optimizer_attribute(deterministic_model, "log_to_console", verbosity)
 
-    elseif occursin("Gurobi", ECModel.optimizer)
+    elseif occursin("Gurobi", optimizer_name)
         set_optimizer_attribute(model, "MIPGap", tol)
         set_optimizer_attribute(model, "TimeLimit", time_limit)
         set_optimizer_attribute(model, "Threads", threads)
@@ -1307,7 +1315,7 @@ function set_parameters_ECmodel!(ECModel::AbstractEC,
         set_optimizer_attribute(deterministic_model, "OutputFlag", verbosity)
 
     else
-        @warn "Optimizer of the EC Model not found"
+        @warn "Optimizer of the EC Model not found" optimizer = optimizer_name
     end
 
     return ECModel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,26 +97,3 @@ end
     end
 
 end
-
-# Regression test for the optimizer-name coercion in `set_parameters_ECmodel!`.
-# Previously, `occursin("Solver", ECModel.optimizer)` raised `MethodError` when
-# the optimizer was passed as a Type (e.g. `HiGHS.Optimizer`), so the function
-# silently bypassed every parameter assignment for the most common JuMP idiom.
-mutable struct _SetParamsECModelMock <: AbstractEC
-    model::JuMP.Model
-    deterministic_model::JuMP.Model
-    optimizer
-end
-
-@testset "set_parameters_ECmodel! coerces optimizer Type to string" begin
-    em = _SetParamsECModelMock(
-        JuMP.Model(HiGHS.Optimizer),
-        JuMP.Model(HiGHS.Optimizer),
-        HiGHS.Optimizer,  # passed as a Type, the common JuMP idiom
-    )
-    set_parameters_ECmodel!(em, 1e-7, 30, 1, 0)
-    for jm in (em.model, em.deterministic_model)
-        @test MOI.get(jm, MOI.RawOptimizerAttribute("mip_rel_gap")) ≈ 1e-7
-        @test MOI.get(jm, MOI.RawOptimizerAttribute("time_limit")) ≈ 30.0
-    end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,3 +97,26 @@ end
     end
 
 end
+
+# Regression test for the optimizer-name coercion in `set_parameters_ECmodel!`.
+# Previously, `occursin("Solver", ECModel.optimizer)` raised `MethodError` when
+# the optimizer was passed as a Type (e.g. `HiGHS.Optimizer`), so the function
+# silently bypassed every parameter assignment for the most common JuMP idiom.
+mutable struct _SetParamsECModelMock <: AbstractEC
+    model::JuMP.Model
+    deterministic_model::JuMP.Model
+    optimizer
+end
+
+@testset "set_parameters_ECmodel! coerces optimizer Type to string" begin
+    em = _SetParamsECModelMock(
+        JuMP.Model(HiGHS.Optimizer),
+        JuMP.Model(HiGHS.Optimizer),
+        HiGHS.Optimizer,  # passed as a Type, the common JuMP idiom
+    )
+    set_parameters_ECmodel!(em, 1e-7, 30, 1, 0)
+    for jm in (em.model, em.deterministic_model)
+        @test MOI.get(jm, MOI.RawOptimizerAttribute("mip_rel_gap")) ≈ 1e-7
+        @test MOI.get(jm, MOI.RawOptimizerAttribute("time_limit")) ≈ 30.0
+    end
+end


### PR DESCRIPTION
## Summary

`set_parameters_ECmodel!` silently bypasses every parameter assignment when the optimizer is passed as a Type — the most common JuMP idiom — because `occursin("CPLEX|HiGHS|Gurobi", ECModel.optimizer)` raises `MethodError` on `(::String, ::DataType)`. Callers that guarded the call with `occursin("…", string(typeof(opt)))` (which yields the literal `"DataType"`) skip it altogether, so models silently ship the solver's default tolerances — easy to miss, hard to diagnose.

The fix coerces `ECModel.optimizer` to a string once at the top of the function, so Type / instance / String inputs all hit the same dispatch path. The `@warn` for unknown optimizers also reports the resolved name so the next caller can diagnose immediately.

## Reproduction (pre-fix)

```julia
using EnergyCommunity, JuMP, HiGHS, MathOptInterface
const MOI = MathOptInterface
mutable struct M <: AbstractEC
    model::JuMP.Model
    deterministic_model::JuMP.Model
    optimizer
end
em = M(JuMP.Model(HiGHS.Optimizer), JuMP.Model(HiGHS.Optimizer), HiGHS.Optimizer)
set_parameters_ECmodel!(em, 1e-7, 30, 1, 0)
# pre-fix:  MethodError or silent no-op (depending on call path)
# post-fix: MOI.get(em.deterministic_model, MOI.RawOptimizerAttribute("mip_rel_gap")) == 1.0e-7
```

We hit this from outside while wiring up SMS++ TwoStageStochasticBlock reference values: every Julia run was actually using Gurobi's default `MIPGap=1e-4` even though the harness was nominally passing `1e-5`.

## Test plan

- New `@testset "set_parameters_ECmodel! coerces optimizer Type to string"` in `test/runtests.jl` constructs a minimal `AbstractEC` mock with the optimizer passed as `HiGHS.Optimizer` (a Type) and asserts that `mip_rel_gap` and `time_limit` actually land on both the stochastic and the deterministic-equivalent JuMP model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)